### PR TITLE
Implement and test TranDB.flow(events1, events2)

### DIFF
--- a/TranDB.py
+++ b/TranDB.py
@@ -149,6 +149,33 @@ class TranDBTestCases(unittest.TestCase):
         exp_return_val = "?, ?"
         self.assertEqual(exp_return_val, self.cut._get_insert_data_values_question_mark_string(num_headers))
 
+    def test_flow_general_case_and_incomplete_case_and_unsorted_case(self):
+        e0 = (0, 'WR', '0xc0ffee')
+        e1 = (10, 'RD', '0xc0ffee')
+        e2 = (30, 'WR', '0x00beef')
+        e3 = (50, 'RD', '0x00beef')
+
+        # General case
+        fst_events = [e0, e2]
+        snd_events = [e1, e3]
+
+        exp_flow = [e0, e1, e2, e3]
+        self.assertEqual(exp_flow, self.cut.flow(fst_events, snd_events))
+
+        # Incomplete sequences
+        fst_events = [e0, e2]
+        snd_events = [e1]
+
+        exp_flow = [e0, e1, e2]
+        self.assertEqual(exp_flow, self.cut.flow(fst_events, snd_events))
+
+        # Unsorted case
+        fst_events = [e2, e0]
+        snd_events = [e3, e1]
+
+        exp_flow = [e0, e1, e2, e3]
+        self.assertEqual(exp_flow, self.cut.flow(fst_events, snd_events))
+
     @mock.patch("TranDB.sqlite3")
     def test_can_create_db_file_from_csv(self, mock_sqlite3):
         self.set_log_file_variables(contents=[["0", "RD"], ["1", "WR"]])

--- a/TranDB.py
+++ b/TranDB.py
@@ -54,6 +54,29 @@ class TranDB:
         self.cursor.executemany(insert_data_string, log_file_contents)
         self.connection.commit()
 
+    def flow(self, events1, events2, log_file=None):
+        # Ensure that both sets are sorted by time. Assume "Time" is column 0.
+        events_list = [events1, events2]
+        for (index, evnts) in enumerate(events_list):
+            is_sorted = \
+                all(evnts[i][0] <= evnts[i+1][0] for i in range(len(evnts)-1))
+            if not is_sorted:
+                events_list[index] = sorted(evnts, key=lambda event: event[0])
+
+        # Build the flow object up iteratively by finding the first event from
+        # the second set that follows each event from the first set.
+        flow = []
+        for event1 in events_list[0]:
+            flow.append(event1)
+
+            # Add the next subsequent event to the flow if there is one
+            subseq_evts = [e for e in events_list[1] if e[0] > event1[0]]
+            if subseq_evts:
+                next_event = subseq_evts[0]
+                flow.append(next_event)
+
+        return flow
+
     def _get_db_name(self, log_file):
         return f"{self._get_stripped_log_file_name(log_file)}.db"
 


### PR DESCRIPTION
Addresses issue #1.

This implementation handles the case where 2 sets of events are input to the `flow` method. The unit tests now also include a method that tests the general case, the case with incomplete sequences, and the case with unsorted input.

Additionally, I'd like to point out that the db[key] usage from the README doesn't seem to work as intended. For example, calling db["Command == WR"] raises a sqlite3.ProgrammingError on my machine. I know how to fix it, but am not sure if this is actually a bug or just me doing something wrong. I suggest someone put it up as an official issue if it doesn't work on other machines either.